### PR TITLE
feat: Modify nav and calendar page

### DIFF
--- a/app/Http/Controllers/GoogleAuthController.php
+++ b/app/Http/Controllers/GoogleAuthController.php
@@ -27,6 +27,7 @@ class GoogleAuthController extends Controller
                     'google_id' => $googleUser->getId(),
                     'google_token' => $googleUser->token,
                     'google_refresh_token' => $googleUser->refreshToken,
+                    'avatar' => $googleUser->getAvatar(),
                 ]);
             } else {
                 $user = User::create([
@@ -35,6 +36,7 @@ class GoogleAuthController extends Controller
                     'google_id' => $googleUser->getId(),
                     'google_token' => $googleUser->token,
                     'google_refresh_token' => $googleUser->refreshToken,
+                    'avatar' => $googleUser->getAvatar(),
                 ]);
 
                 // Crear un apiario por defecto para el nuevo usuario

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'google_token',
         'google_refresh_token',
         'role',
+        'avatar',
     ];
 
     /**

--- a/database/migrations/2025_08_03_141542_add_avatar_to_users_table.php
+++ b/database/migrations/2025_08_03_141542_add_avatar_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar')->nullable()->after('google_refresh_token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('avatar');
+        });
+    }
+};

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -7,8 +7,40 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900" id='calendar'>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <!-- Calendar Section -->
+                <div class="md:col-span-2">
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div class="p-6 text-gray-900" id='calendar'>
+                            <!-- Calendar will be rendered here -->
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Tasks and Events Panel -->
+                <div class="md:col-span-1">
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div class="p-6">
+                            <h3 class="text-lg font-semibold mb-4">Tareas y Eventos</h3>
+                            <ul class="space-y-4">
+                                <!-- Placeholder Item 1 -->
+                                <li class="border-l-4 border-blue-500 pl-4">
+                                    <p class="font-semibold">Revisar Colmena #3</p>
+                                    <p class="text-sm text-gray-500">15 de Agosto, 2025</p>
+                                </li>
+                                <!-- Placeholder Item 2 -->
+                                <li class="border-l-4 border-green-500 pl-4">
+                                    <p class="font-semibold">Cosecha de Miel</p>
+                                    <p class="text-sm text-gray-500">20 de Agosto, 2025</p>
+                                </li>
+                                <!-- Placeholder Item 3 -->
+                                <li class="border-l-4 border-yellow-500 pl-4">
+                                    <p class="font-semibold">Tratamiento de Varroa</p>
+                                    <p class="text-sm text-gray-500">1 de Septiembre, 2025</p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -13,13 +13,13 @@
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Panel') }}
-                    </x-nav-link>
-                    <x-nav-link :href="route('hives.index')" :active="request()->routeIs('hives.index')">
-                        {{ __('Colmenas') }}
+                        {{ __('Dashboard') }}
                     </x-nav-link>
                     <x-nav-link :href="route('apiaries.index')" :active="request()->routeIs('apiaries.index')">
                         {{ __('Apiarios') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('hives.index')" :active="request()->routeIs('hives.index')">
+                        {{ __('Colmenas') }}
                     </x-nav-link>
                     <x-nav-link :href="route('calendar.index')" :active="request()->routeIs('calendar.index')">
                         {{ __('Calendario') }}
@@ -35,6 +35,9 @@
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-text-light bg-surface hover:text-text-dark focus:outline-none transition ease-in-out duration-150">
+                            @if (Auth::user()->avatar)
+                                <img src="{{ Auth::user()->avatar }}" alt="User Avatar" class="h-8 w-8 rounded-full object-cover mr-2">
+                            @endif
                             <div>{{ Auth::user()->name }}</div>
 
                             <div class="ms-1">
@@ -80,13 +83,13 @@
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Panel') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link :href="route('hives.index')" :active="request()->routeIs('hives.index')">
-                {{ __('Colmenas') }}
+                {{ __('Dashboard') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('apiaries.index')" :active="request()->routeIs('apiaries.index')">
                 {{ __('Apiarios') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('hives.index')" :active="request()->routeIs('hives.index')">
+                {{ __('Colmenas') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('calendar.index')" :active="request()->routeIs('calendar.index')">
                 {{ __('Calendario') }}


### PR DESCRIPTION
- Change 'Panel' to 'Dashboard' in the navigation bar.
- Reorder 'Apiarios' and 'Colmenas' links.
- Add your Google profile picture to the settings dropdown.
- Redesign the calendar page with a smaller calendar and a new panel for tasks and events.
- Add a migration to store your avatar URL.
- Update the User model and GoogleAuthController to handle the avatar.