### PR TITLE
feat: Implement bulk actions for hives

### DIFF
--- a/app/Http/Controllers/ApiaryController.php
+++ b/app/Http/Controllers/ApiaryController.php
@@ -54,9 +54,9 @@ class ApiaryController extends Controller
         }
 
         // Sort
-        $sort = $request->get('sort', 'name');
+        $sort = $request->get('sort', 'status');
         $direction = $request->get('direction', 'asc');
-        if (in_array($sort, ['name', 'status', 'type', 'birth_date']) && in_array($direction, ['asc', 'desc'])) {
+        if (in_array($sort, ['name', 'status', 'type', 'birth_date', 'rating', 'updated_at']) && in_array($direction, ['asc', 'desc'])) {
             $query->orderBy($sort, $direction);
         }
 
@@ -67,8 +67,9 @@ class ApiaryController extends Controller
         }
 
         $hives = $query->paginate($perPage)->appends($request->query());
+        $allApiaries = Apiary::where('user_id', auth()->id())->where('id', '!=', $apiary->id)->get();
 
-        return view('apiaries.show', compact('apiary', 'hives', 'sort', 'direction', 'perPage'));
+        return view('apiaries.show', compact('apiary', 'hives', 'sort', 'direction', 'perPage', 'allApiaries'));
     }
 
     /**

--- a/app/Http/Controllers/HiveController.php
+++ b/app/Http/Controllers/HiveController.php
@@ -97,4 +97,27 @@ class HiveController extends Controller
 
         return redirect()->route('hives.index')->with('success', 'Hive deleted successfully.');
     }
+
+    public function bulkActions(Request $request)
+    {
+        $validatedData = $request->validate([
+            'action' => 'required|in:move,delete',
+            'hive_ids' => 'required|array',
+            'hive_ids.*' => 'exists:hives,id',
+            'apiary_id' => 'required_if:action,move|exists:apiaries,id',
+        ]);
+
+        $hiveIds = $validatedData['hive_ids'];
+
+        switch ($validatedData['action']) {
+            case 'move':
+                Hive::whereIn('id', $hiveIds)->update(['apiary_id' => $validatedData['apiary_id']]);
+                return response()->json(['success' => true, 'message' => 'Hives moved successfully.']);
+            case 'delete':
+                Hive::whereIn('id', $hiveIds)->delete();
+                return response()->json(['success' => true, 'message' => 'Hives deleted successfully.']);
+        }
+
+        return response()->json(['success' => false, 'message' => 'Invalid action.'], 400);
+    }
 }

--- a/resources/views/apiaries/show.blade.php
+++ b/resources/views/apiaries/show.blade.php
@@ -58,51 +58,75 @@
                 </div>
 
 
+                <div id="bulk-actions" class="hidden mb-4">
+                    <button id="move-button" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">{{ __('Mover') }}</button>
+                    <button id="delete-button" class="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600">{{ __('Borrar') }}</button>
+                </div>
+
                 <div class="bg-white rounded-lg shadow-md overflow-hidden">
                     <div class="overflow-x-auto">
                         <table class="min-w-full bg-white">
                             <thead class="bg-primary text-text-dark">
                                 <tr>
                                     <th class="py-3 px-4 uppercase font-semibold text-sm">
-                                        <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'name', 'direction' => $sort === 'name' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
-                                            Nombre
-                                            @if ($sort === 'name')
-                                                <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
-                                            @endif
-                                        </a>
-                                    </th>
-                                    <th class="py-3 px-4 uppercase font-semibold text-sm">
-                                        <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'type', 'direction' => $sort === 'type' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
-                                            Tipo
-                                            @if ($sort === 'type')
-                                                <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
-                                            @endif
-                                        </a>
+                                        <input type="checkbox" id="select-all">
                                     </th>
                                     <th class="py-3 px-4 uppercase font-semibold text-sm">
                                         <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'status', 'direction' => $sort === 'status' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
-                                            Estado
+                                            {{ __('Estado') }}
                                             @if ($sort === 'status')
                                                 <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
                                             @endif
                                         </a>
                                     </th>
                                     <th class="py-3 px-4 uppercase font-semibold text-sm">
+                                        <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'name', 'direction' => $sort === 'name' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
+                                            {{ __('Nombre') }}
+                                            @if ($sort === 'name')
+                                                <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
+                                            @endif
+                                        </a>
+                                    </th>
+                                    <th class="py-3 px-4 uppercase font-semibold text-sm">
+                                        <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'updated_at', 'direction' => $sort === 'updated_at' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
+                                            {{ __('Ultima Modificacion') }}
+                                            @if ($sort === 'updated_at')
+                                                <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
+                                            @endif
+                                        </a>
+                                    </th>
+                                    <th class="py-3 px-4 uppercase font-semibold text-sm">
                                         <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'birth_date', 'direction' => $sort === 'birth_date' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
-                                            Fecha de nacimiento
+                                            {{ __('Fecha de nacimiento') }}
                                             @if ($sort === 'birth_date')
                                                 <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
                                             @endif
                                         </a>
                                     </th>
-                                    <th class="py-3 px-4 uppercase font-semibold text-sm">Acciones</th>
+                                    <th class="py-3 px-4 uppercase font-semibold text-sm">
+                                        <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'rating', 'direction' => $sort === 'rating' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
+                                            {{ __('Rating') }}
+                                            @if ($sort === 'rating')
+                                                <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
+                                            @endif
+                                        </a>
+                                    </th>
+                                    <th class="py-3 px-4 uppercase font-semibold text-sm">
+                                        <a class="hover:text-primary-dark" href="{{ route('apiaries.show', array_merge(request()->query(), ['apiary' => $apiary, 'sort' => 'type', 'direction' => $sort === 'type' && $direction === 'asc' ? 'desc' : 'asc'])) }}">
+                                            {{ __('Tipo') }}
+                                            @if ($sort === 'type')
+                                                <span class="ml-1">{{ $direction === 'asc' ? '▲' : '▼' }}</span>
+                                            @endif
+                                        </a>
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody class="text-gray-700">
                                 @forelse ($hives as $hive)
                                     <tr class="border-b hover:bg-background">
-                                        <td class="py-3 px-4">{{ $hive->name }}</td>
-                                        <td class="py-3 px-4">{{ $hive->type }}</td>
+                                        <td class="py-3 px-4">
+                                            <input type="checkbox" class="hive-checkbox" value="{{ $hive->id }}">
+                                        </td>
                                         <td class="py-3 px-4">
                                             <span class="px-2 py-1 text-xs font-semibold text-white rounded-full {{
                                                 match($hive->status) {
@@ -116,14 +140,17 @@
                                                 }
                                             }}">{{ $hive->status }}</span>
                                         </td>
-                                        <td class="py-3 px-4">{{ $hive->birth_date ? $hive->birth_date->format('d/m/Y') : 'N/A' }}</td>
                                         <td class="py-3 px-4">
-                                            <a href="{{ route('hives.show', $hive) }}" class="text-sm text-green-600 hover:text-green-900 font-semibold">Ver Colmena</a>
+                                            <a href="{{ route('hives.show', $hive) }}" class="text-sm text-green-600 hover:text-green-900 font-semibold">{{ $hive->name }}</a>
                                         </td>
+                                        <td class="py-3 px-4">{{ $hive->updated_at->format('d/m/Y H:i') }}</td>
+                                        <td class="py-3 px-4">{{ $hive->birth_date ? $hive->birth_date->format('d/m/Y') : 'N/A' }}</td>
+                                        <td class="py-3 px-4">{{ $hive->rating ?? 'N/A' }}</td>
+                                        <td class="py-3 px-4">{{ $hive->type }}</td>
                                     </tr>
                                 @empty
                                     <tr>
-                                        <td colspan="5" class="text-center py-12">
+                                        <td colspan="7" class="text-center py-12">
                                             <p class="text-gray-500 text-lg">{{ __('No hay colmenas que coincidan con la búsqueda.') }}</p>
                                         </td>
                                     </tr>
@@ -138,4 +165,155 @@
             </div>
         </div>
     </div>
+
+    <!-- Move Modal -->
+    <div id="move-modal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="mt-3 text-center">
+                <h3 class="text-lg leading-6 font-medium text-gray-900">{{ __('Mover Colmenas') }}</h3>
+                <div class="mt-2 px-7 py-3">
+                    <select id="move-apiary-select" class="w-full rounded-md border-gray-300 shadow-sm">
+                        @foreach ($allApiaries as $apiaryOption)
+                            <option value="{{ $apiaryOption->id }}">{{ $apiaryOption->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="items-center px-4 py-3">
+                    <button id="confirm-move-button" class="px-4 py-2 bg-blue-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300">
+                        {{ __('Confirmar') }}
+                    </button>
+                    <button id="cancel-move-button" class="px-4 py-2 bg-gray-300 text-gray-800 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                        {{ __('Cancelar') }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Delete Modal -->
+    <div id="delete-modal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="mt-3 text-center">
+                <h3 class="text-lg leading-6 font-medium text-gray-900">{{ __('Borrar Colmenas') }}</h3>
+                <div class="mt-2 px-7 py-3">
+                    <p>{{ __('¿Estás seguro de que quieres borrar las colmenas seleccionadas?') }}</p>
+                </div>
+                <div class="items-center px-4 py-3">
+                    <button id="confirm-delete-button" class="px-4 py-2 bg-red-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-300">
+                        {{ __('Confirmar') }}
+                    </button>
+                    <button id="cancel-delete-button" class="px-4 py-2 bg-gray-300 text-gray-800 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                        {{ __('Cancelar') }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const selectAllCheckbox = document.getElementById('select-all');
+            const hiveCheckboxes = document.querySelectorAll('.hive-checkbox');
+            const bulkActionsDiv = document.getElementById('bulk-actions');
+            const moveButton = document.getElementById('move-button');
+            const deleteButton = document.getElementById('delete-button');
+            const moveModal = document.getElementById('move-modal');
+            const deleteModal = document.getElementById('delete-modal');
+            const confirmMoveButton = document.getElementById('confirm-move-button');
+            const cancelMoveButton = document.getElementById('cancel-move-button');
+            const confirmDeleteButton = document.getElementById('confirm-delete-button');
+            const cancelDeleteButton = document.getElementById('cancel-delete-button');
+            const moveApiarySelect = document.getElementById('move-apiary-select');
+
+            function getSelectedHiveIds() {
+                const selectedIds = [];
+                hiveCheckboxes.forEach(checkbox => {
+                    if (checkbox.checked) {
+                        selectedIds.push(checkbox.value);
+                    }
+                });
+                return selectedIds;
+            }
+
+            function updateBulkActionsVisibility() {
+                const selectedIds = getSelectedHiveIds();
+                if (selectedIds.length > 0) {
+                    bulkActionsDiv.classList.remove('hidden');
+                } else {
+                    bulkActionsDiv.classList.add('hidden');
+                }
+            }
+
+            selectAllCheckbox.addEventListener('change', function () {
+                hiveCheckboxes.forEach(checkbox => {
+                    checkbox.checked = selectAllCheckbox.checked;
+                });
+                updateBulkActionsVisibility();
+            });
+
+            hiveCheckboxes.forEach(checkbox => {
+                checkbox.addEventListener('change', updateBulkActionsVisibility);
+            });
+
+            moveButton.addEventListener('click', function () {
+                moveModal.classList.remove('hidden');
+            });
+
+            deleteButton.addEventListener('click', function () {
+                deleteModal.classList.remove('hidden');
+            });
+
+            cancelMoveButton.addEventListener('click', function () {
+                moveModal.classList.add('hidden');
+            });
+
+            cancelDeleteButton.addEventListener('click', function () {
+                deleteModal.classList.add('hidden');
+            });
+
+            confirmMoveButton.addEventListener('click', function () {
+                const hiveIds = getSelectedHiveIds();
+                const apiaryId = moveApiarySelect.value;
+                performBulkAction('move', hiveIds, apiaryId);
+            });
+
+            confirmDeleteButton.addEventListener('click', function () {
+                const hiveIds = getSelectedHiveIds();
+                performBulkAction('delete', hiveIds);
+            });
+
+            function performBulkAction(action, hiveIds, apiaryId = null) {
+                const data = {
+                    action: action,
+                    hive_ids: hiveIds,
+                    _token: '{{ csrf_token() }}'
+                };
+
+                if (apiaryId) {
+                    data.apiary_id = apiaryId;
+                }
+
+                fetch('{{ route("hives.bulkActions") }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                    },
+                    body: JSON.stringify(data)
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        window.location.reload();
+                    } else {
+                        alert(data.message || 'An error occurred.');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('An error occurred.');
+                });
+            }
+        });
+    </script>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ Route::get('/dashboard', function () {
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::resource('hives', HiveController::class)->middleware(['auth', 'role:admin,superadmin']);
+Route::post('/hives/bulk-actions', [HiveController::class, 'bulkActions'])->name('hives.bulkActions')->middleware(['auth', 'role:admin,superadmin']);
 Route::resource('apiaries', ApiaryController::class)->middleware(['auth', 'role:admin,superadmin']);
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
This commit introduces bulk actions (move and delete) for hives in the apiary view.

- Adds checkboxes to the hives table to select multiple hives.
- Adds 'Mover' (Move) and 'Borrar' (Delete) buttons that appear when hives are selected.
- Implements modals for moving hives to a different apiary and for confirming deletion.
- Adds `rating` and `updated_at` columns to the hives table and makes them sortable.
- Reorders the columns as per the requirements.
- The hive name is now a link to the hive's detail page, and the old 'Acciones' column has been removed.
- Adds the necessary backend logic, including a new route and a controller method, to handle the bulk actions.