### PR TITLE
feat: Add tabs, notes, and activity log to apiary view

### DIFF
--- a/app/Models/Apiary.php
+++ b/app/Models/Apiary.php
@@ -50,4 +50,14 @@ class Apiary extends Model
     {
         return $this->hasMany(Hive::class);
     }
+
+    public function notes()
+    {
+        return $this->hasMany(ApiaryNote::class)->latest();
+    }
+
+    public function activities()
+    {
+        return $this->hasMany(ApiaryActivity::class)->latest();
+    }
 }

--- a/app/Models/ApiaryActivity.php
+++ b/app/Models/ApiaryActivity.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ApiaryActivity extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'apiary_id',
+        'user_id',
+        'description',
+    ];
+
+    public function apiary()
+    {
+        return $this->belongsTo(Apiary::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ApiaryNote.php
+++ b/app/Models/ApiaryNote.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ApiaryNote extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'apiary_id',
+        'content',
+    ];
+
+    public function apiary()
+    {
+        return $this->belongsTo(Apiary::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Policies/ApiaryNotePolicy.php
+++ b/app/Policies/ApiaryNotePolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ApiaryNote;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ApiaryNotePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\ApiaryNote  $apiaryNote
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, ApiaryNote $apiaryNote)
+    {
+        return $user->id === $apiaryNote->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\ApiaryNote  $apiaryNote
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, ApiaryNote $apiaryNote)
+    {
+        return $user->id === $apiaryNote->user_id;
+    }
+}

--- a/app/Traits/LogsApiaryActivity.php
+++ b/app/Traits/LogsApiaryActivity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Apiary;
+use App\Models\ApiaryActivity;
+
+trait LogsApiaryActivity
+{
+    /**
+     * Log an activity for an apiary.
+     *
+     * @param \App\Models\Apiary $apiary
+     * @param string $description
+     * @return void
+     */
+    protected function logActivity(Apiary $apiary, string $description)
+    {
+        ApiaryActivity::create([
+            'apiary_id' => $apiary->id,
+            'user_id' => auth()->id(),
+            'description' => $description,
+        ]);
+    }
+}

--- a/database/migrations/2025_08_10_100000_create_apiary_notes_table.php
+++ b/database/migrations/2025_08_10_100000_create_apiary_notes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('apiary_notes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('apiary_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('apiary_notes');
+    }
+};

--- a/database/migrations/2025_08_10_100100_create_apiary_activities_table.php
+++ b/database/migrations/2025_08_10_100100_create_apiary_activities_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('apiary_activities', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('apiary_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('apiary_activities');
+    }
+};

--- a/resources/views/apiaries/partials/note.blade.php
+++ b/resources/views/apiaries/partials/note.blade.php
@@ -1,0 +1,31 @@
+<div class="flex items-start space-x-4" id="note-{{ $note->id }}">
+    <img class="w-10 h-10 rounded-full" src="{{ $note->user->avatar ?? 'https://ui-avatars.com/api/?name=' . urlencode($note->user->name) . '&color=7F9CF5&background=EBF4FF' }}" alt="{{ $note->user->name }}">
+    <div class="flex-1">
+        <div class="bg-gray-100 rounded-lg p-4">
+            <div class="flex items-center justify-between">
+                <p class="font-semibold text-gray-900">{{ $note->user->name }}</p>
+                <div class="text-xs text-gray-500">
+                    {{ $note->created_at->diffForHumans() }}
+                    @if ($note->created_at != $note->updated_at)
+                        (editado)
+                    @endif
+                </div>
+            </div>
+            <p class="text-gray-700 mt-2 note-content">{{ $note->content }}</p>
+        </div>
+        @if (auth()->id() == $note->user_id)
+            <div class="flex items-center space-x-4 mt-1 text-xs">
+                <button class="font-medium text-blue-600 hover:text-blue-800 edit-note-button" data-note-id="{{ $note->id }}">Editar</button>
+                <button class="font-medium text-red-600 hover:text-red-800 delete-note-button" data-note-id="{{ $note->id }}">Eliminar</button>
+            </div>
+
+            <div id="edit-note-form-{{ $note->id }}" class="hidden mt-2">
+                <textarea class="w-full rounded-md border-gray-300 shadow-sm focus:border-primary focus:ring focus:ring-primary-light focus:ring-opacity-50" rows="3">{{ $note->content }}</textarea>
+                <div class="flex justify-end space-x-2 mt-2">
+                    <button class="px-3 py-1 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 cancel-edit-button" data-note-id="{{ $note->id }}">Cancelar</button>
+                    <button class="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 confirm-edit-button" data-note-id="{{ $note->id }}">Guardar</button>
+                </div>
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -35,5 +35,6 @@
                 {{ $slot }}
             </main>
         </div>
+        @stack('scripts')
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,12 @@ Route::resource('hives', HiveController::class)->middleware(['auth', 'role:admin
 Route::post('/hives/bulk-actions', [HiveController::class, 'bulkActions'])->name('hives.bulkActions')->middleware(['auth', 'role:admin,superadmin']);
 Route::resource('apiaries', ApiaryController::class)->middleware(['auth', 'role:admin,superadmin']);
 
+Route::middleware(['auth', 'role:admin,superadmin'])->group(function () {
+    Route::post('/apiaries/{apiary}/notes', [ApiaryController::class, 'storeNote'])->name('apiaries.notes.store');
+    Route::patch('/apiaries/{apiary}/notes/{note}', [ApiaryController::class, 'updateNote'])->name('apiaries.notes.update');
+    Route::delete('/apiaries/{apiary}/notes/{note}', [ApiaryController::class, 'destroyNote'])->name('apiaries.notes.destroy');
+});
+
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
This commit implements a new tabbed interface on the apiary detail page with three sections: Hives, Notes, and Activity.

- **Hives Tab:** Displays the existing list of hives for the apiary.

- **Notes Tab:**
  - Introduces a new `apiary_notes` table and `ApiaryNote` model.
  - You can now add, edit, and delete notes for an apiary.
  - The interface is styled like a group chat, showing the author and timestamp.
  - All note operations are handled asynchronously via AJAX for a smooth user experience.

- **Activity Tab:**
  - Adds an `apiary_activities` table and `ApiaryActivity` model.
  - A new `LogsApiaryActivity` trait is used to record important events.
  - Activities are logged for:
    - Apiary creation, status updates, and deletion.
    - Hive creation, deletion, and moving between apiaries.
  - The activity log is displayed in a new read-only tab.

The implementation includes the necessary database migrations, model relationships, controller logic, routes, and extensive view modifications with JavaScript.