### PR TITLE
feat: Add harvest tracking feature

### DIFF
--- a/app/Http/Controllers/HarvestController.php
+++ b/app/Http/Controllers/HarvestController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Harvest;
+use App\Models\Hive;
+use Illuminate\Http\Request;
+use App\Traits\LogsHiveActivity;
+
+class HarvestController extends Controller
+{
+    use LogsHiveActivity;
+
+    public function store(Request $request, Hive $hive)
+    {
+        $validatedData = $request->validate([
+            'harvest_date' => 'required|date',
+            'quantity_kg' => 'nullable|numeric|min:0',
+            'quantity_liters' => 'nullable|numeric|min:0',
+            'density' => 'required|numeric|min:0',
+            'color_tone' => 'required|string',
+            'origin' => 'required|string',
+            'notes' => 'nullable|string',
+        ]);
+
+        if (empty($validatedData['quantity_kg']) && empty($validatedData['quantity_liters'])) {
+            return back()->withErrors(['quantity_kg' => 'Debe proporcionar la cantidad en kilogramos o litros.'])->withInput();
+        }
+
+        if (!empty($validatedData['quantity_kg'])) {
+            $validatedData['quantity_liters'] = $validatedData['quantity_kg'] / $validatedData['density'];
+        } elseif (!empty($validatedData['quantity_liters'])) {
+            $validatedData['quantity_kg'] = $validatedData['quantity_liters'] * $validatedData['density'];
+        }
+
+        $harvest = $hive->harvests()->create($validatedData);
+
+        $this->logActivity($hive, "Se registró una cosecha de {$harvest->quantity_kg} kg.");
+
+        return redirect()->route('hives.show', $hive)->with('success', 'Cosecha registrada exitosamente.');
+    }
+}

--- a/app/Http/Controllers/HiveController.php
+++ b/app/Http/Controllers/HiveController.php
@@ -76,7 +76,7 @@ class HiveController extends Controller
      */
     public function show(Hive $hive)
     {
-        $hive->load('queen', 'queenHistories', 'inspections', 'events', 'tags', 'notes.user', 'activities.user');
+        $hive->load('queen', 'queenHistories', 'inspections', 'harvests', 'latestHarvest', 'tags', 'notes.user', 'activities.user');
         $apiaries = Apiary::where('user_id', auth()->id())->get();
         $statuses = Hive::getStatusOptions();
         $types = Hive::getTypeOptions();

--- a/app/Models/Harvest.php
+++ b/app/Models/Harvest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Harvest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'hive_id',
+        'harvest_date',
+        'quantity_kg',
+        'quantity_liters',
+        'density',
+        'color_tone',
+        'origin',
+        'notes',
+    ];
+
+    protected $casts = [
+        'harvest_date' => 'date',
+    ];
+
+    public function hive()
+    {
+        return $this->belongsTo(Hive::class);
+    }
+}

--- a/app/Models/Hive.php
+++ b/app/Models/Hive.php
@@ -61,6 +61,16 @@ class Hive extends Model
         return $this->hasMany(Inspection::class);
     }
 
+    public function harvests()
+    {
+        return $this->hasMany(Harvest::class);
+    }
+
+    public function latestHarvest()
+    {
+        return $this->hasOne(Harvest::class)->latestOfMany();
+    }
+
     public function events()
     {
         return $this->hasMany(Event::class);

--- a/database/migrations/2025_08_11_031514_create_harvests_table.php
+++ b/database/migrations/2025_08_11_031514_create_harvests_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('harvests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('hive_id')->constrained()->onDelete('cascade');
+            $table->date('harvest_date');
+            $table->decimal('quantity_kg', 8, 2);
+            $table->decimal('quantity_liters', 8, 2);
+            $table->decimal('density', 5, 2)->default(1.42);
+            $table->string('color_tone');
+            $table->string('origin');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('harvests');
+    }
+};

--- a/resources/views/hives/partials/harvest-form.blade.php
+++ b/resources/views/hives/partials/harvest-form.blade.php
@@ -1,0 +1,71 @@
+<div class="bg-white rounded-lg shadow-md p-6">
+    <h3 class="text-xl font-semibold text-gray-800 mb-4">Registrar Nueva Cosecha</h3>
+    <form action="{{ route('hives.harvests.store', $hive) }}" method="POST">
+        @csrf
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Harvest Date -->
+            <div>
+                <x-input-label for="harvest_date" :value="__('Fecha de Cosecha')" />
+                <x-text-input id="harvest_date" class="block mt-1 w-full" type="date" name="harvest_date" :value="old('harvest_date', date('Y-m-d'))" required />
+                <x-input-error :messages="$errors->get('harvest_date')" class="mt-2" />
+            </div>
+
+            <!-- Origin -->
+            <div>
+                <x-input-label for="origin" :value="__('Origen de la Miel')" />
+                <select id="origin" name="origin" class="block mt-1 w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm" required>
+                    <option value="Flores silvestres" @if(old('origin') == 'Flores silvestres') selected @endif>Flores silvestres</option>
+                    <option value="Cultivos" @if(old('origin') == 'Cultivos') selected @endif>Cultivos</option>
+                    <option value="Alimentación artificial" @if(old('origin') == 'Alimentación artificial') selected @endif>Alimentación artificial</option>
+                    <option value="Otro" @if(old('origin') == 'Otro') selected @endif>Otro</option>
+                </select>
+                <x-input-error :messages="$errors->get('origin')" class="mt-2" />
+            </div>
+
+            <!-- Quantity KG -->
+            <div>
+                <x-input-label for="quantity_kg" :value="__('Cantidad (kg)')" />
+                <x-text-input id="quantity_kg" class="block mt-1 w-full" type="number" step="0.01" name="quantity_kg" :value="old('quantity_kg')" />
+                <x-input-error :messages="$errors->get('quantity_kg')" class="mt-2" />
+            </div>
+
+            <!-- Quantity Liters -->
+            <div>
+                <x-input-label for="quantity_liters" :value="__('Cantidad (litros)')" />
+                <x-text-input id="quantity_liters" class="block mt-1 w-full" type="number" step="0.01" name="quantity_liters" :value="old('quantity_liters')" />
+                <x-input-error :messages="$errors->get('quantity_liters')" class="mt-2" />
+            </div>
+
+            <!-- Density -->
+            <div>
+                <x-input-label for="density" :value="__('Densidad (kg/l)')" />
+                <x-text-input id="density" class="block mt-1 w-full" type="number" step="0.01" name="density" :value="old('density', '1.42')" required />
+                <x-input-error :messages="$errors->get('density')" class="mt-2" />
+            </div>
+
+            <!-- Color Tone -->
+            <div>
+                <x-input-label for="color_tone" :value="__('Tono de Color')" />
+                <input id="color_tone" name="color_tone" type="range" min="0" max="100" value="{{ old('color_tone', '50') }}" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700">
+                <div class="flex justify-between text-xs text-gray-500">
+                    <span>Claro</span>
+                    <span>Oscuro</span>
+                </div>
+                <x-input-error :messages="$errors->get('color_tone')" class="mt-2" />
+            </div>
+
+            <!-- Notes -->
+            <div class="md:col-span-2">
+                <x-input-label for="notes" :value="__('Notas Adicionales')" />
+                <textarea id="notes" name="notes" rows="3" class="w-full rounded-md border-gray-300 shadow-sm focus:border-primary focus:ring-primary-light">{{ old('notes') }}</textarea>
+                <x-input-error :messages="$errors->get('notes')" class="mt-2" />
+            </div>
+        </div>
+
+        <div class="flex items-center justify-end mt-6">
+            <x-primary-button>
+                {{ __('Registrar Cosecha') }}
+            </x-primary-button>
+        </div>
+    </form>
+</div>

--- a/resources/views/hives/partials/harvest-history.blade.php
+++ b/resources/views/hives/partials/harvest-history.blade.php
@@ -1,0 +1,35 @@
+<div class="mt-8">
+    <h3 class="text-xl font-semibold text-gray-800 mb-4">Historial de Cosechas</h3>
+    <div class="space-y-6">
+        @forelse ($hive->harvests->sortByDesc('harvest_date') as $harvest)
+            <div class="bg-white rounded-lg shadow-md overflow-hidden">
+                <div class="p-6 sm:flex sm:items-center sm:justify-between">
+                    <div class="sm:flex sm:items-center">
+                        <div class="flex-shrink-0">
+                            <svg class="h-12 w-12 text-yellow-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10s5 2 5 2l-2.646 2.646a.5.5 0 00.708.708L15 12.5V15a1 1 0 001 1h.5a1 1 0 001-1v-2.5l2.121-2.121a.5.5 0 00-.353-.854H18a1 1 0 00-1 1v1.5l-2.646 2.646a.5.5 0 00.708.708L17.5 15V12a1 1 0 00-1-1h-1.5a1 1 0 00-1 1v1.5l-2.646 2.646a.5.5 0 00.708.708L15 15.5V18a1 1 0 001 1h.5a1 1 0 001-1v-2.5l2.121-2.121a.5.5 0 00-.353-.854H18a1 1 0 00-1 1v1.5l-2.646 2.646a.5.5 0 00.708.708L17.5 18H19a1 1 0 001-1v-1.5l-2.121-2.121a.5.5 0 00-.854.353V15a1 1 0 001 1h.5a1 1 0 001-1v-1.5l-2.121-2.121a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1h-1.5a1 1 0 00-1 1V12l-2.646 2.646a.5.5 0 00.708.708L12.5 12H15a1 1 0 001-1V9.5a1 1 0 00-1-1h-1.5a1 1 0 00-1 1V12l-2.646 2.646a.5.5 0 00.708.708L10 12h2.5a1 1 0 001-1V9.5a1 1 0 00-1-1H12a1 1 0 00-1 1v2.5L8.879 9.379a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1H9a1 1 0 00-1 1v2.5L5.879 9.379a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1H6a1 1 0 00-1 1v2.5L2.879 9.379a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1H3a1 1 0 00-1 1v2.5a8 8 0 0115.657 5.157z"/>
+                            </svg>
+                        </div>
+                        <div class="mt-4 sm:mt-0 sm:ml-6 text-center sm:text-left">
+                            <p class="text-xl font-bold text-gray-900">{{ $harvest->quantity_kg }} kg</p>
+                            <p class="text-sm text-gray-600">{{ $harvest->harvest_date->format('d/m/Y') }}</p>
+                        </div>
+                    </div>
+                    <div class="mt-4 sm:mt-0 text-center sm:text-right">
+                        <p class="text-sm text-gray-600">Origen: {{ $harvest->origin }}</p>
+                        <p class="text-sm text-gray-600">Color: {{ $harvest->color_tone }}</p>
+                    </div>
+                </div>
+                @if ($harvest->notes)
+                <div class="px-6 py-4 bg-gray-50 border-t border-gray-200">
+                    <p class="text-sm text-gray-700">{{ $harvest->notes }}</p>
+                </div>
+                @endif
+            </div>
+        @empty
+            <div class="text-center py-12">
+                <p class="text-gray-500 text-lg">No hay cosechas registradas para esta colmena.</p>
+            </div>
+        @endforelse
+    </div>
+</div>

--- a/resources/views/hives/show.blade.php
+++ b/resources/views/hives/show.blade.php
@@ -49,6 +49,15 @@
                                 <span class="font-bold text-lg text-gray-800">{{ $hive->rating ?? 'N/A' }}</span>
                                 <span class="text-gray-600">/ 100</span>
                             </div>
+                            @if($hive->latestHarvest)
+                                <div class="flex items-center space-x-1">
+                                    <svg class="h-6 w-6 text-yellow-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10s5 2 5 2l-2.646 2.646a.5.5 0 00.708.708L15 12.5V15a1 1 0 001 1h.5a1 1 0 001-1v-2.5l2.121-2.121a.5.5 0 00-.353-.854H18a1 1 0 00-1 1v1.5l-2.646 2.646a.5.5 0 00.708.708L17.5 15V12a1 1 0 00-1-1h-1.5a1 1 0 00-1 1v1.5l-2.646 2.646a.5.5 0 00.708.708L15 15.5V18a1 1 0 001 1h.5a1 1 0 001-1v-2.5l2.121-2.121a.5.5 0 00-.353-.854H18a1 1 0 00-1 1v1.5l-2.646 2.646a.5.5 0 00.708.708L17.5 18H19a1 1 0 001-1v-1.5l-2.121-2.121a.5.5 0 00-.854.353V15a1 1 0 001 1h.5a1 1 0 001-1v-1.5l-2.121-2.121a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1h-1.5a1 1 0 00-1 1V12l-2.646 2.646a.5.5 0 00.708.708L12.5 12H15a1 1 0 001-1V9.5a1 1 0 00-1-1h-1.5a1 1 0 00-1 1V12l-2.646 2.646a.5.5 0 00.708.708L10 12h2.5a1 1 0 001-1V9.5a1 1 0 00-1-1H12a1 1 0 00-1 1v2.5L8.879 9.379a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1H9a1 1 0 00-1 1v2.5L5.879 9.379a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1H6a1 1 0 00-1 1v2.5L2.879 9.379a.5.5 0 00-.854.353V12a1 1 0 001 1h1.5a1 1 0 001-1V9.5a1 1 0 00-1-1H3a1 1 0 00-1 1v2.5a8 8 0 0115.657 5.157z"/>
+                                    </svg>
+                                    <span class="font-bold text-lg text-gray-800">{{ $hive->latestHarvest->quantity_kg }} kg</span>
+                                    <span class="text-gray-600">({{ $hive->latestHarvest->harvest_date->format('d/m/Y') }})</span>
+                                </div>
+                            @endif
                             @if($hive->location_gps)
                                 <a href="https://www.google.com/maps/search/?api=1&query={{ $hive->location_gps }}" target="_blank" class="inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-800">
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
@@ -160,11 +169,14 @@
                     <button class="tab-button whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm border-primary text-primary" data-tab="inspections">
                         {{ __('Inspecciones') }}
                     </button>
+                    <button class="tab-button whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" data-tab="harvest">
+                        {{ __('Cosecha') }}
+                    </button>
                     <button class="tab-button whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" data-tab="queen">
                         {{ __('Reina') }}
                     </button>
-                    <button class="tab-button whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" data-tab="events">
-                        {{ __('Eventos') }}
+                    <button class="tab-button whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" data-tab="general">
+                        {{ __('General') }}
                     </button>
                     <button class="tab-button whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" data-tab="notes">
                         {{ __('Notas') }}
@@ -324,18 +336,16 @@
                 <!-- Inspections Tab -->
                 @include('hives.partials.inspections', ['hive' => $hive])
 
-                <!-- Events Tab -->
-                <div id="events-content" class="tab-content hidden">
-                    <h4 class="text-xl font-semibold mb-4">Historial de Eventos</h4>
-                    @forelse ($hive->events as $event)
-                        <div class="border-l-4 border-green-400 pl-4 mb-4">
-                            <p><strong>Fecha:</strong> {{ $event->event_date->format('d/m/Y') }}</p>
-                            <p><strong>Tipo:</strong> {{ $event->type }}</p>
-                            <p><strong>Detalles:</strong> {{ $event->details }}</p>
-                        </div>
-                    @empty
-                        <p>No hay eventos registrados.</p>
-                    @endforelse
+                <!-- Harvest Tab -->
+                <div id="harvest-content" class="tab-content hidden">
+                    @include('hives.partials.harvest-form', ['hive' => $hive])
+                    @include('hives.partials.harvest-history', ['hive' => $hive])
+                </div>
+
+                <!-- General Tab -->
+                <div id="general-content" class="tab-content hidden">
+                    <h4 class="text-xl font-semibold mb-4">Información General</h4>
+                    <p>Aquí se mostrará información general de la colmena.</p>
                 </div>
 
                 <!-- Notes Tab -->
@@ -699,6 +709,51 @@
                     });
                 }
             });
+        }
+
+        // Harvest form logic
+        const quantityKgInput = document.getElementById('quantity_kg');
+        const quantityLitersInput = document.getElementById('quantity_liters');
+        const densityInput = document.getElementById('density');
+
+        if (quantityKgInput && quantityLitersInput && densityInput) {
+            quantityKgInput.addEventListener('input', () => {
+                if (document.activeElement === quantityKgInput) {
+                    const kg = parseFloat(quantityKgInput.value);
+                    const density = parseFloat(densityInput.value);
+                    if (!isNaN(kg) && !isNaN(density) && density > 0) {
+                        quantityLitersInput.value = (kg / density).toFixed(2);
+                    }
+                }
+            });
+
+            quantityLitersInput.addEventListener('input', () => {
+                if (document.activeElement === quantityLitersInput) {
+                    const liters = parseFloat(quantityLitersInput.value);
+                    const density = parseFloat(densityInput.value);
+                    if (!isNaN(liters) && !isNaN(density)) {
+                        quantityKgInput.value = (liters * density).toFixed(2);
+                    }
+                }
+            });
+        }
+
+        const colorSlider = document.getElementById('color_tone');
+        if(colorSlider){
+            const colorDisplay = document.createElement('div');
+            colorDisplay.className = 'w-full h-4 mt-2 rounded-full';
+            const updateColor = () => {
+                const value = colorSlider.value; // 0-100
+                const lightColor = [255, 235, 59]; // Yellow
+                const darkColor = [183, 28, 28]; // Dark Red
+                const r = Math.round(lightColor[0] + (darkColor[0] - lightColor[0]) * (value / 100));
+                const g = Math.round(lightColor[1] + (darkColor[1] - lightColor[1]) * (value / 100));
+                const b = Math.round(lightColor[2] + (darkColor[2] - lightColor[2]) * (value / 100));
+                colorDisplay.style.backgroundColor = `rgb(${r}, ${g}, ${b})`;
+            };
+            updateColor();
+            colorSlider.parentNode.insertBefore(colorDisplay, colorSlider.nextSibling.nextSibling);
+            colorSlider.addEventListener('input', updateColor);
         }
         });
     </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\HiveController;
 use App\Http\Controllers\ApiaryController;
 use App\Http\Controllers\HiveNoteController;
 use App\Http\Controllers\QueenController;
+use App\Http\Controllers\HarvestController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -39,6 +40,9 @@ Route::middleware(['auth', 'role:admin,superadmin'])->group(function () {
 
     // Inspection routes
     Route::post('/hives/{hive}/inspections', [App\Http\Controllers\InspectionController::class, 'store'])->name('hives.inspections.store');
+
+    // Harvest routes
+    Route::post('/hives/{hive}/harvests', [HarvestController::class, 'store'])->name('hives.harvests.store');
 });
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
This commit introduces a new feature for tracking honey harvests from beehives.

- Replaces the "Events" tab with two new tabs: "Harvest" and "General".
- Adds a form to the "Harvest" tab to register new harvests, including details like date, quantity (kg or liters), density, color tone, and origin.
- Implements frontend logic for automatic calculation between kg and liters and a visual color slider.
- Displays a history of harvests on the "Harvest" tab.
- Adds a summary of the latest harvest to the main hive information card.
- Includes the necessary backend support: a new `harvests` table, `Harvest` model, `HarvestController`, and routes.