### PR TITLE
feat: Enhance hive state system with categories and positive states

### DIFF
--- a/app/Http/Controllers/HiveController.php
+++ b/app/Http/Controllers/HiveController.php
@@ -105,12 +105,23 @@ class HiveController extends Controller
      */
     public function show(Hive $hive)
     {
-        $hive->load('queen', 'queenHistories', 'inspections', 'harvests', 'latestHarvest', 'tags', 'notes.user', 'activities.user', 'hiveSupers', 'states');
+        $hive->load([
+            'queen',
+            'queenHistories',
+            'inspections' => fn($query) => $query->orderBy('inspection_date', 'desc'),
+            'harvests',
+            'latestHarvest',
+            'tags',
+            'notes.user',
+            'activities.user',
+            'hiveSupers',
+            'states'
+        ]);
         $apiaries = Apiary::where('user_id', auth()->id())->get();
         $types = Hive::getTypeOptions();
         $lastInspection = $hive->inspections()->latest('inspection_date')->first();
         $unassignedSupers = HiveSuper::whereNull('hive_id')->get();
-        $states = \App\Models\State::all();
+        $states = \App\Models\State::all()->groupBy('category');
 
         return view('hives.show', compact('hive', 'apiaries', 'types', 'lastInspection', 'unassignedSupers', 'states'));
     }

--- a/app/Models/Inspection.php
+++ b/app/Models/Inspection.php
@@ -101,14 +101,40 @@ class Inspection extends Model
 
         // Pests and diseases
         if ($this->pests_diseases !== 'Sin plagas') {
-            $state = State::firstOrCreate(['name' => $this->pests_diseases], ['description' => 'Presencia de ' . $this->pests_diseases, 'type' => 'bad']);
+            $state = State::firstOrCreate(['name' => $this->pests_diseases], ['description' => 'Presencia de ' . $this->pests_diseases, 'type' => 'bad', 'category' => 'Plagas y Enfermedades']);
             $statesToSync[$state->id] = ['cause' => $cause];
 
             if ($this->treatments === 'Sin tratamiento') {
-                $state = State::firstOrCreate(['name' => 'Enferma sin tratamiento'], ['description' => 'La colmena está enferma y no está recibiendo tratamiento.', 'type' => 'bad']);
+                $state = State::firstOrCreate(['name' => 'Enferma sin tratamiento'], ['description' => 'La colmena está enferma y no está recibiendo tratamiento.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)']);
                 $statesToSync[$state->id] = ['cause' => $cause];
             } else {
-                $state = State::firstOrCreate(['name' => 'Enferma con tratamiento'], ['description' => 'La colmena está enferma y está recibiendo tratamiento.', 'type' => 'neutral']);
+                $state = State::firstOrCreate(['name' => 'Enferma con tratamiento'], ['description' => 'La colmena está enferma y está recibiendo tratamiento.', 'type' => 'neutral', 'category' => 'Indicadores de Inspección (Negativo)']);
+                $statesToSync[$state->id] = ['cause' => $cause];
+            }
+        } else {
+            // Positive states only if there are no pests or diseases
+            if ($this->population > 80 && $this->honey_stores > 80 && $this->pollen_stores > 80 && $this->brood_pattern > 80 && $this->behavior < 20) {
+                $state = State::firstOrCreate(['name' => 'Óptima'], ['description' => 'La colmena está en condiciones óptimas.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)']);
+                $statesToSync[$state->id] = ['cause' => $cause];
+            } elseif ($this->population > 60 && $this->honey_stores > 60 && $this->pollen_stores > 60 && $this->brood_pattern > 60 && $this->behavior < 40) {
+                $state = State::firstOrCreate(['name' => 'Activa'], ['description' => 'La colmena está activa y saludable.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)']);
+                $statesToSync[$state->id] = ['cause' => $cause];
+            }
+
+            if ($this->honey_stores > 80) {
+                $state = State::firstOrCreate(['name' => 'Buenas reservas de miel'], ['description' => 'La colmena tiene abundantes reservas de miel.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)']);
+                $statesToSync[$state->id] = ['cause' => $cause];
+            }
+            if ($this->pollen_stores > 80) {
+                $state = State::firstOrCreate(['name' => 'Buenas reservas de polen'], ['description' => 'La colmena tiene abundantes reservas de polen.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)']);
+                $statesToSync[$state->id] = ['cause' => $cause];
+            }
+            if ($this->brood_pattern > 80) {
+                $state = State::firstOrCreate(['name' => 'Buena cría'], ['description' => 'El patrón de cría es excelente.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)']);
+                $statesToSync[$state->id] = ['cause' => $cause];
+            }
+            if ($this->behavior < 20) {
+                $state = State::firstOrCreate(['name' => 'Dócil'], ['description' => 'La colmena tiene un comportamiento muy dócil.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)']);
                 $statesToSync[$state->id] = ['cause' => $cause];
             }
         }

--- a/app/Models/State.php
+++ b/app/Models/State.php
@@ -13,6 +13,7 @@ class State extends Model
         'name',
         'description',
         'type',
+        'category',
     ];
 
     public function hives()

--- a/database/migrations/2025_08_12_000004_add_category_to_states_table.php
+++ b/database/migrations/2025_08_12_000004_add_category_to_states_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('states', function (Blueprint $table) {
+            $table->string('category')->nullable()->after('type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('states', function (Blueprint $table) {
+            $table->dropColumn('category');
+        });
+    }
+};

--- a/database/seeders/StateSeeder.php
+++ b/database/seeders/StateSeeder.php
@@ -13,25 +13,60 @@ class StateSeeder extends Seeder
     public function run(): void
     {
         $states = [
-            ['name' => 'Huerfana', 'description' => 'La colmena no tiene reina.', 'type' => 'bad'],
-            ['name' => 'Población baja', 'description' => 'La población de abejas es baja.', 'type' => 'bad'],
-            ['name' => 'Reservas de miel bajas', 'description' => 'Las reservas de miel son bajas.', 'type' => 'bad'],
-            ['name' => 'Reservas de polen bajas', 'description' => 'Las reservas de polen son bajas.', 'type' => 'bad'],
-            ['name' => 'Agresiva', 'description' => 'La colmena es muy agresiva.', 'type' => 'bad'],
-            ['name' => 'Enferma sin tratamiento', 'description' => 'La colmena está enferma y no está recibiendo tratamiento.', 'type' => 'bad'],
-            ['name' => 'Enferma con tratamiento', 'description' => 'La colmena está enferma y está recibiendo tratamiento.', 'type' => 'neutral'],
-            ['name' => 'Varroa', 'description' => 'Presencia de Varroa.', 'type' => 'bad'],
-            ['name' => 'Loque Americana', 'description' => 'Presencia de Loque Americana.', 'type' => 'bad'],
-            ['name' => 'Loque Europea', 'description' => 'Presencia de Loque Europea.', 'type' => 'bad'],
-            ['name' => 'Polilla de la cera', 'description' => 'Presencia de Polilla de la cera.', 'type' => 'bad'],
-            ['name' => 'Escarabajo de la colmena', 'description' => 'Presencia de Escarabajo de la colmena.', 'type' => 'bad'],
-            ['name' => 'Nariz blanca', 'description' => 'Presencia de Nariz blanca.', 'type' => 'bad'],
-            ['name' => 'Piojo de la abeja', 'description' => 'Presencia de Piojo de la abeja.', 'type' => 'bad'],
-            ['name' => 'Acaro traqueal', 'description' => 'Presencia de Acaro traqueal.', 'type' => 'bad'],
+            // Indicadores de Inspección (Negativo)
+            ['name' => 'Huerfana', 'description' => 'La colmena no tiene reina.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)'],
+            ['name' => 'Población baja', 'description' => 'La población de abejas es baja.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)'],
+            ['name' => 'Reservas de miel bajas', 'description' => 'Las reservas de miel son bajas.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)'],
+            ['name' => 'Reservas de polen bajas', 'description' => 'Las reservas de polen son bajas.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)'],
+            ['name' => 'Agresiva', 'description' => 'La colmena es muy agresiva.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)'],
+            ['name' => 'Enferma sin tratamiento', 'description' => 'La colmena está enferma y no está recibiendo tratamiento.', 'type' => 'bad', 'category' => 'Indicadores de Inspección (Negativo)'],
+            ['name' => 'Enferma con tratamiento', 'description' => 'La colmena está enferma y está recibiendo tratamiento.', 'type' => 'neutral', 'category' => 'Indicadores de Inspección (Negativo)'],
+
+            // Plagas y Enfermedades
+            ['name' => 'Varroa', 'description' => 'Presencia de Varroa.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Loque Americana', 'description' => 'Presencia de Loque Americana.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Loque Europea', 'description' => 'Presencia de Loque Europea.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Polilla de la cera', 'description' => 'Presencia de Polilla de la cera.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Escarabajo de la colmena', 'description' => 'Presencia de Escarabajo de la colmena.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Nariz blanca', 'description' => 'Presencia de Nariz blanca.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Piojo de la abeja', 'description' => 'Presencia de Piojo de la abeja.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+            ['name' => 'Acaro traqueal', 'description' => 'Presencia de Acaro traqueal.', 'type' => 'bad', 'category' => 'Plagas y Enfermedades'],
+
+            // Indicadores de Inspección (Positivo)
+            ['name' => 'Óptima', 'description' => 'La colmena está en condiciones óptimas.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)'],
+            ['name' => 'Activa', 'description' => 'La colmena está activa y saludable.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)'],
+            ['name' => 'Buenas reservas de miel', 'description' => 'La colmena tiene abundantes reservas de miel.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)'],
+            ['name' => 'Buenas reservas de polen', 'description' => 'La colmena tiene abundantes reservas de polen.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)'],
+            ['name' => 'Buena cría', 'description' => 'El patrón de cría es excelente.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)'],
+            ['name' => 'Dócil', 'description' => 'La colmena tiene un comportamiento muy dócil.', 'type' => 'good', 'category' => 'Indicadores de Inspección (Positivo)'],
+
+            // Anomalías
+            ['name' => 'Enjambrazón', 'description' => 'La colmena está mostrando signos de enjambrazón.', 'type' => 'bad', 'category' => 'Anomalías'],
+            ['name' => 'Zanganera', 'description' => 'La colmena se ha vuelto zanganera.', 'type' => 'bad', 'category' => 'Anomalías'],
+
+            // Estados sociales
+            ['name' => 'Pillaje', 'description' => 'La colmena está siendo pillada por otras abejas.', 'type' => 'bad', 'category' => 'Estados sociales'],
+            ['name' => 'Pillera', 'description' => 'La colmena está pillando a otras.', 'type' => 'bad', 'category' => 'Estados sociales'],
+            ['name' => 'Deriva', 'description' => 'Se observa deriva de abejas de otras colmenas.', 'type' => 'neutral', 'category' => 'Estados sociales'],
+
+            // Estados de estación del año
+            ['name' => 'Expansión', 'description' => 'La colmena está en fase de expansión.', 'type' => 'good', 'category' => 'Estados de estación del año'],
+            ['name' => 'Producción', 'description' => 'La colmena está en plena producción de miel.', 'type' => 'good', 'category' => 'Estados de estación del año'],
+            ['name' => 'Almacenamiento', 'description' => 'La colmena está almacenando reservas para el invierno.', 'type' => 'good', 'category' => 'Estados de estación del año'],
+            ['name' => 'Invernando', 'description' => 'La colmena está invernando.', 'type' => 'neutral', 'category' => 'Estados de estación del año'],
+
+            // Estados de administración
+            ['name' => 'Revisión', 'description' => 'La colmena está programada para revisión.', 'type' => 'neutral', 'category' => 'Estados de administración'],
+            ['name' => 'Mantenimiento', 'description' => 'Se está realizando mantenimiento en la colmena.', 'type' => 'neutral', 'category' => 'Estados de administración'],
+            ['name' => 'Alimentación artificial', 'description' => 'Se está aplicando alimentación artificial.', 'type' => 'neutral', 'category' => 'Estados de administración'],
+            ['name' => 'Unión', 'description' => 'La colmena está en proceso de ser unida con otra.', 'type' => 'neutral', 'category' => 'Estados de administración'],
+            ['name' => 'División', 'description' => 'La colmena ha sido dividida o está en proceso de división.', 'type' => 'neutral', 'category' => 'Estados de administración'],
+            ['name' => 'Crianza de reinas', 'description' => 'Se está utilizando la colmena para la crianza de reinas.', 'type' => 'neutral', 'category' => 'Estados de administración'],
+            ['name' => 'Sin uso', 'description' => 'La colmena no está en uso.', 'type' => 'neutral', 'category' => 'Estados de administración'],
         ];
 
         foreach ($states as $stateData) {
-            State::firstOrCreate(['name' => $stateData['name']], $stateData);
+            State::updateOrCreate(['name' => $stateData['name']], $stateData);
         }
     }
 }

--- a/resources/views/hives/partials/inspections.blade.php
+++ b/resources/views/hives/partials/inspections.blade.php
@@ -145,7 +145,7 @@
     <div class="mt-8">
         <h4 class="text-xl font-semibold mb-4">Historial de Inspecciones</h4>
         <div class="space-y-6">
-            @forelse ($hive->inspections->sortByDesc('inspection_date') as $inspection)
+            @forelse ($hive->inspections as $inspection)
                 <div class="bg-gray-50 rounded-lg shadow-md p-6 border border-gray-200">
                     <div class="flex justify-between items-start">
                         <div>

--- a/resources/views/hives/show.blade.php
+++ b/resources/views/hives/show.blade.php
@@ -168,15 +168,24 @@
                     @csrf
                     @method('PATCH')
 
-                    <div>
-                        <x-input-label for="states" :value="__('Estados Manuales')" />
-                        <select id="states" name="states[]" multiple class="block mt-1 w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm">
-                            @foreach ($states as $state)
-                                <option value="{{ $state->id }}" @if ($hive->states->where('pivot.cause', 'Manual')->contains($state->id)) selected @endif>{{ $state->name }}</option>
-                            @endforeach
-                        </select>
-                        <x-input-error :messages="$errors->get('states')" class="mt-2" />
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        @foreach ($states as $category => $statesInCategory)
+                            @if($category && !Str::contains($category, 'Inspección'))
+                            <div class="p-4 border rounded-lg">
+                                <h4 class="font-semibold text-lg mb-2">{{ $category }}</h4>
+                                <div class="space-y-2">
+                                    @foreach ($statesInCategory as $state)
+                                        <label for="state-{{ $state->id }}" class="flex items-center">
+                                            <input type="checkbox" id="state-{{ $state->id }}" name="states[]" value="{{ $state->id }}" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" @if ($hive->states->where('pivot.cause', 'Manual')->contains($state->id)) checked @endif>
+                                            <span class="ml-2 text-sm text-gray-600">{{ $state->name }}</span>
+                                        </label>
+                                    @endforeach
+                                </div>
+                            </div>
+                            @endif
+                        @endforeach
                     </div>
+                    <x-input-error :messages="$errors->get('states')" class="mt-2" />
 
 
                     <div class="flex items-center justify-end mt-6">


### PR DESCRIPTION
This commit enhances the hive state system with several new features:

- Adds a 'category' to states to group them for better UI.
- Seeds the database with a comprehensive list of new states, including anomalies, social states, seasonal states, and administrative states.
- Enhances the automatic state logic to include positive states (e.g., 'Óptima', 'Buenas reservas de miel') when inspection data is favorable.
- Refactors the manual state management UI to use grouped checkboxes, improving user experience.
- Ensures the inspection list is sorted correctly (most recent first) and that the new inspection form is pre-filled with the latest data.